### PR TITLE
feature: Allow exporting several images at a time

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -199,22 +199,24 @@ const exportSettings: ExportSetting[] = [
 const main = async (command: string) => {
   if (figma.currentPage.selection && figma.currentPage.selection.length > 0) {
     figma.showUI(__html__, { visible: false })
-    const selected = figma.currentPage.selection[0]
+    const selected = figma.currentPage.selection
     const exportAssets: Asset[] = await Promise.all(
       exportSettings
         .filter(setting => setting.command.includes(command))
-        .map(async setting => {
-          const name =
-            selected.name
-              .replace(/\s/g, '')
-              .split('/')
-              .pop()
-              ?.toString() || 'noname'
-          return {
-            name,
-            setting,
-            bytes: await selected.exportAsync(setting.fileSetting),
-          }
+        .flatMap(setting => {
+          return selected.map(async item => {
+            const name =
+              item.name
+                .replace(/\s/g, '')
+                .split('/')
+                .pop()
+                ?.toString() || 'noname'
+            return {
+              name,
+              setting,
+              bytes: await item.exportAsync(setting.fileSetting),
+            }
+          })
         }),
     )
 


### PR DESCRIPTION
I don't know if the project is open for contributions, but I found your Figma plugin to be the best one to export assets to Android: others froze, didn't separate the assets in drawable-XXXX folders or didn't work at all.

However, having to export one image at a time was way too slow for me so I took a look at your code and added some code to export several assets at the same time. I've been using it for a while and I haven't found any issues yet but feel free to test it.